### PR TITLE
Object::Meta::File module

### DIFF
--- a/lib/Object/Meta.pm
+++ b/lib/Object/Meta.pm
@@ -24,7 +24,7 @@ Object::Meta - Library to manage raw data and meta data as one object but keepin
 
 package Object::Meta;
 
-our $VERSION = '1.1.1';
+our $VERSION = '1.2.0';
 
 #----------------------------------------------------------------------------
 #Dependencies

--- a/lib/Object/Meta.pm
+++ b/lib/Object/Meta.pm
@@ -69,10 +69,9 @@ using key and value pairs.
 
 sub new {
     my $class = ref( $_[0] ) || $_[0];
-    my $self  = undef;
 
     #Set the Default Attributes and assign the initial Values
-    $self = [ {}, {} ];
+    my $self = [ {}, {} ];
 
     #Bestow Objecthood
     bless $self, $class;

--- a/lib/Object/Meta/File.pm
+++ b/lib/Object/Meta/File.pm
@@ -1,0 +1,153 @@
+#
+# @author Bodo (Hugo) Barwich
+# @version 2026-01-29
+# @package Object::Meta
+# @subpackage lib/Object/Meta/File.pm
+
+# This Module defines Classes to manage Data in an indexed List
+#
+#---------------------------------
+# Requirements:
+#
+#---------------------------------
+# Features:
+#
+
+#==============================================================================
+# The Object::Meta::File Package
+
+=head1 NAME
+
+Object::Meta::File - Library to recognise a special C<directoryname> field from the raw data
+
+=cut
+
+package Object::Meta::File;
+
+#----------------------------------------------------------------------------
+#Dependencies
+
+use parent 'Object::Meta::Named';
+
+=head1 DESCRIPTION
+
+C<Object::Meta::File> implements a class which adds a C<name> and a C<directoryname> field
+to the raw data which can be used to index the C<Object::Meta> entries.
+It works exactly like the C<Object::Meta::Named> class.
+
+Additionally a C<hash> meta data field will be created for indexation and lookup.
+
+The C<hash> meta data field becomes the index field.
+
+=cut
+
+#----------------------------------------------------------------------------
+#Constructors
+
+=head1 METHODS
+
+=head2 Constructor
+
+=head3 new ( [ DATA ] )
+
+This is the constructor for a new C<Object::Meta::File> object.
+It creates a new object from B<raw data> which is passed in a hash key / value pairs.
+
+B<Parameters:>
+
+=over 4
+
+=item C<DATA>
+
+The B<raw data> which is passed in a hash key / value pairs.
+
+If a C<name> field is present it will be used to index the entry.
+
+If a C<directoryname> field is present it will be passed to the C<setDirectoryName()>
+method.
+
+=back
+
+See L<Method C<Object::Meta::Named::new()>|Object::Meta::Named/"new ( [ DATA ] )">
+
+=cut
+
+sub new {
+    my $invocant = shift;
+    my $class    = ref($invocant) || $invocant;
+    my $self     = undef;
+
+    #Take the Method Parameters
+    my %hshprms = @_;
+
+    $self = $class->SUPER::new(@_);
+
+    if ( defined $hshprms{'directoryname'} ) {
+        $self->setDirectoryName( $hshprms{'directoryname'} );
+    }
+    else {
+        $self->setDirectoryName;
+    }
+
+    #Give the Object back
+    return $self;
+}
+
+#----------------------------------------------------------------------------
+#Administration Methods
+
+=head2 Administration Methods
+
+=head3 setDirectoryName ( [ DIRECTORY ] )
+
+This will create a C<directoryname> field in the raw data.
+
+B<Parameters:>
+
+=over 4
+
+=item C<DIRECTORY>
+
+The string value for the directory name of the object.
+
+If C<DIRECTORY> is empty or is undefined it will empty the C<directoryname> field.
+
+If C<DIRECTORY> does not have a trailing slash C< / > it will be added.
+
+=back
+
+=cut
+
+sub setDirectoryName {
+    my $self = shift;
+
+    if ( scalar(@_) > 0 ) {
+        $self->set( 'directoryname', shift );
+    }
+    else {
+        $self->set( 'directoryname', '' );
+    }
+
+    if ( $self->[Object::Meta::LIST_DATA]{'directoryname'} ne '' ) {
+        $self->[Object::Meta::LIST_DATA]{'directoryname'} .= '/'
+          unless ( $self->[Object::Meta::LIST_DATA]{'directoryname'} =~ m#/$# );
+
+    }
+}
+
+#----------------------------------------------------------------------------
+#Consultation Methods
+
+=head2 Consultation Methods
+
+=head3 getDirectoryName ()
+
+Returns the content of the C<directoryname> field.
+
+=cut
+
+sub getDirectoryName {
+    return $_[0]->[Object::Meta::LIST_DATA]{'directoryname'};
+}
+
+return 1;

--- a/lib/Object/Meta/File.pm
+++ b/lib/Object/Meta/File.pm
@@ -73,20 +73,18 @@ See L<Method C<Object::Meta::Named::new()>|Object::Meta::Named/"new ( [ DATA ] )
 =cut
 
 sub new {
-    my $invocant = shift;
-    my $class    = ref($invocant) || $invocant;
-    my $self     = undef;
+    my $class = ref( $_[0] ) || $_[0];
 
     #Take the Method Parameters
-    my %hshprms = @_;
+    my %hshprms = @_[ 1 .. $#_ ];
 
-    $self = $class->SUPER::new(@_);
+    my $self = $class->SUPER::new(%hshprms);
 
     if ( defined $hshprms{'directoryname'} ) {
-        $self->setDirectoryName( $hshprms{'directoryname'} );
+        Object::Meta::File::setDirectoryName( $self, $hshprms{'directoryname'} );
     }
     else {
-        $self->setDirectoryName;
+        Object::Meta::File::setDirectoryName $self;
     }
 
     #Give the Object back
@@ -97,6 +95,27 @@ sub new {
 #Administration Methods
 
 =head2 Administration Methods
+
+=head3 set ( DATA )
+
+This overrides the base method C<Object::Meta::Named::set()> to recognize the
+C<name> and C<directoryname> field.
+
+See L<Method C<Object::Meta::Named::set()>|Object::Meta::Named/"set ( DATA )">
+
+See L<Method C<Object::Meta::set()>|Object::Meta/"set ( DATA )">
+
+=cut
+
+sub set {
+    my ( $self, %hshprms ) = @_;
+
+    if ( defined $hshprms{'directoryname'} ) {
+        Object::Meta::File::setDirectoryName( $self, delete $hshprms{'directoryname'} );
+    }
+
+    Object::Meta::Named::set( $self, %hshprms );
+}
 
 =head3 setDirectoryName ( [ DIRECTORY ] )
 
@@ -119,13 +138,13 @@ If C<DIRECTORY> does not have a trailing slash C< / > it will be added.
 =cut
 
 sub setDirectoryName {
-    my $self = shift;
+    my $self = $_[0];
 
-    if ( scalar(@_) > 0 ) {
-        $self->set( 'directoryname', shift );
+    if ( scalar(@_) > 1 ) {
+        Object::Meta::set( $self, 'directoryname', $_[1] );
     }
     else {
-        $self->set( 'directoryname', '' );
+        Object::Meta::set( $self, 'directoryname', '' );
     }
 
     if ( $self->[Object::Meta::LIST_DATA]{'directoryname'} ne '' ) {

--- a/lib/Object/Meta/File/List.pm
+++ b/lib/Object/Meta/File/List.pm
@@ -1,0 +1,114 @@
+#
+# @author Bodo (Hugo) Barwich
+# @version 2026-01-29
+# @package Object::Meta
+# @subpackage lib/Object/Meta/File/List.pm
+
+# This Module defines Classes to manage Data in an indexed List
+#
+#---------------------------------
+# Requirements:
+#
+#---------------------------------
+# Features:
+#
+
+#==============================================================================
+# The Object::Meta::File::List Package
+
+=head1 NAME
+
+Object::Meta::File::List - Library to index C<Object::Meta::File> instances by
+their C<name> field.
+
+=cut
+
+package Object::Meta::File::List;
+
+#----------------------------------------------------------------------------
+#Dependencies
+
+use parent 'Object::Meta::Named::List';
+
+use Scalar::Util 'blessed';
+
+=head1 DESCRIPTION
+
+C<Object::Meta::File::List> implements a class which indexes C<Object::Meta::File>
+instances by their C<name> field. It works exactly like the C<Object::Meta::Named::List>
+class.
+
+Additionally a C<hash> meta data field will be created for indexation and lookup.
+
+The C<hash> meta data field is used to lookup entries.
+
+=cut
+
+#----------------------------------------------------------------------------
+#Constructors
+
+#----------------------------------------------------------------------------
+#Administration Methods
+
+=head1 METHODS
+
+=head2 Administration Methods
+
+=head3 Add ( [ C<Object::Meta::File> | DATA ] )
+
+This works like C<Object::Meta::List::Add()> only that it handles
+C<Object::Meta::File> instances.
+
+If no parameter is given it creates an empty instance of C<Object::Meta::File>
+and adds it to the list
+
+B<Parameters:>
+
+=over 4
+
+=item C<Object::Meta::File>
+
+An instance of C<Object::Meta::File> to be added to the list.
+
+=item C<DATA>
+
+A hash with data to create an instance of C<Object::Meta::File> and add it to the list.
+
+=back
+
+B<Returns:> C<Object::Meta::File> - The object which was created or added.
+
+See L<Method C<Object::Meta::Named::List::Add()>|Object::Meta::Named::List/"Add ( [ C<Object::Meta::Named> | DATA ] )">
+
+See L<Method C<Object::Meta::List::Add()>|Object::Meta::List/"Add ( [ C<Object::Meta> | DATA ] )">
+
+=cut
+
+sub Add {
+    my $self   = shift;
+    my $mtaety = undef;
+
+    if ( scalar(@_) > 0 ) {
+        if ( defined blessed $_[0] ) {
+            $mtaety = $_[0];
+        }
+        else    #Parameter is not an Object
+        {
+            # Create the new Object::Meta::File object from the given parameters
+            $mtaety = Object::Meta::File->new(@_);
+        }
+    }
+
+    if ( defined $mtaety && !$mtaety->isa('Object::Meta::File') ) {
+        $mtaety = undef;
+    }
+
+    $mtaety = Object::Meta::File->new unless ( defined $mtaety );
+
+    #Execute the Base Logic
+    $self->SUPER::Add($mtaety);
+
+    return $mtaety;
+}
+
+return 1;

--- a/lib/Object/Meta/Named.pm
+++ b/lib/Object/Meta/Named.pm
@@ -19,7 +19,7 @@
 
 =head1 NAME
 
-Object::Meta::Named - Library to recognise a special C<Name> field from the raw data
+Object::Meta::Named - Library to recognise a special C<name> field from the raw data
 
 =cut
 

--- a/lib/Object/Meta/Named/List.pm
+++ b/lib/Object/Meta/Named/List.pm
@@ -19,7 +19,7 @@
 
 =head1 NAME
 
-Object::Meta::Named::List - Library to index C<Object::Meta::Named> entries by
+Object::Meta::Named::List - Library to index C<Object::Meta::Named> instances by
 their C<name> field.
 
 =cut
@@ -32,12 +32,12 @@ package Object::Meta::Named::List;
 use parent 'Object::Meta::List';
 
 use Scalar::Util qw(blessed);
-use Digest::MD5 qw(md5_hex);
+use Digest::MD5  qw(md5_hex);
 
 =head1 DESCRIPTION
 
 C<Object::Meta::Named::List> implements a class which indexes C<Object::Meta::Named>
-entries by their C<name> field.
+instances by their C<name> field.
 
 Additionally a C<hash> meta data field will be created for indexation and lookup.
 
@@ -133,10 +133,8 @@ sub Add {
         }
     }
 
-    if ( defined $mtaety ) {
-        unless ( $mtaety->isa('Object::Meta::Named') ) {
-            $mtaety = undef;
-        }
+    if ( defined $mtaety && !$mtaety->isa('Object::Meta::Named') ) {
+        $mtaety = undef;
     }
 
     $mtaety = Object::Meta::Named::->new unless ( defined $mtaety );

--- a/t/test_file-list.t
+++ b/t/test_file-list.t
@@ -1,15 +1,15 @@
 #!/usr/bin/perl
 
 # @author Bodo (Hugo) Barwich
-# @version 2026-01-26
-# @package Test for the Object::Meta::Named::List Module
+# @version 2026-01-29
+# @package Test for the Object::Meta::File::List Module
 # @subpackage test_object.t
 
-# This Module runs tests on the Object::Meta::Named::List Module
+# This Module runs tests on the Object::Meta::File::List Module
 #
 #---------------------------------
 # Requirements:
-# - The Perl Module "Object::Meta::Named::List" must be installed
+# - The Perl Module "Object::Meta::File::List" must be installed
 #
 
 use warnings;
@@ -24,10 +24,10 @@ BEGIN {
     use lib "../lib";
 }    #BEGIN
 
-require_ok('Object::Meta::Named::List');
+require_ok('Object::Meta::File::List');
 
-use Object::Meta::Named::List;
-use Object::Meta::Named;
+use Object::Meta::File::List;
+use Object::Meta::File;
 
 my $smodule = "";
 my $spath   = abs_path($0);
@@ -37,9 +37,9 @@ $spath =~ s/^(.*\/)$smodule$/$1/;
 
 my $list     = undef;
 my $obj      = undef;
-my %obj1data = ( 'name'    => 'object1', 'field1' => 'value1', 'field2' => 'value2', 'field3' => 'value3' );
-my %obj2data = ( 'name'    => 'object2', 'field1' => 'value4', 'field2' => 'value5', 'field3' => 'value6' );
-my %obj3data = ( 'name'    => 'object3', 'field1' => 'value7', 'field2' => 'value8', 'field3' => 'value9' );
+my %obj1data = ( 'name'    => 'file1', 'directoryname' => 'directory1', 'field2' => 'value2', 'field3' => 'value3' );
+my %obj2data = ( 'name'    => 'file2', 'directoryname' => 'directory4', 'field2' => 'value5', 'field3' => 'value6' );
+my %obj3data = ( 'name'    => 'file3', 'directoryname' => 'directory7', 'field2' => 'value8', 'field3' => 'value9' );
 my %obj1meta = ( 'updated' => 'new' );
 my %obj2meta = ( 'updated' => 'new' );
 my %obj3meta = ( 'updated' => 'updated' );
@@ -50,9 +50,9 @@ subtest 'Constructor' => sub {
     #Test: 'Constructor'
 
     subtest 'empty list' => sub {
-        $list = Object::Meta::Named::List->new();
+        $list = Object::Meta::File::List->new();
 
-        is( ref $list, 'Object::Meta::Named::List', "List 'Object::Meta::Named::List': created correctly" );
+        is( ref $list, 'Object::Meta::File::List', "List 'Object::Meta::File::List': created correctly" );
 
         is( $list->getIndexField(),      'hash', "Index Field 'hash' as expected" );
         is( $list->getMetaObjectCount(), 0,      "List is empty as expected" );
@@ -66,9 +66,9 @@ subtest 'Name Index' => sub {
     #Test: 'Indices'
 
     subtest 'name index with fix value' => sub {
-        $list = Object::Meta::Named::List->new();
+        $list = Object::Meta::File::List->new();
 
-        is( ref $list, 'Object::Meta::Named::List', "List 'Object::Meta::Named::List': created correctly" );
+        is( ref $list, 'Object::Meta::File::List', "List 'Object::Meta::File::List': created correctly" );
 
         is( $list->getMetaObjectCount(), 0,     "List is empty as expected" );
         is( $list->getMetaObject(0),     undef, "Object with Index '0': does not exist as expected" );
@@ -79,19 +79,19 @@ subtest 'Name Index' => sub {
         # Primary Index was created automatically
         is( $list->getIndexField(), 'hash', "Index Field 'hash' as expected" );
 
-        $obj = Object::Meta::Named->new(%obj1data);
+        $obj = Object::Meta::File->new(%obj1data);
 
         $obj->setMeta(%obj1meta);
 
         $list->Add($obj);
 
-        $obj = Object::Meta::Named->new(%obj2data);
+        $obj = Object::Meta::File->new(%obj2data);
 
         $obj->setMeta(%obj2meta);
 
         $list->Add($obj);
 
-        $obj = Object::Meta::Named->new(%obj3data);
+        $obj = Object::Meta::File->new(%obj3data);
 
         $obj->setMeta(%obj3meta);
 
@@ -101,9 +101,10 @@ subtest 'Name Index' => sub {
         is( $list->getIdxMetaObjectCount('new'), 2, "Objects with Meta Field 'new': Count '2'" );
 
         # Find instance by its 'name' field
-        $obj = $list->getMetaObjectbyName('object2');
+        $obj = $list->getMetaObjectbyName('file2');
 
-        is( $obj->getName(), 'object2', "Name Indexed: Instance 'object2' returned" );
+        is( $obj->getName(),          'file2',       "Name Indexed: Instance 'file2' returned" );
+        is( $obj->getDirectoryName(), 'directory4/', "Name Indexed: Field 'directoryname' set correctly" );
     };
 };
 

--- a/t/test_object-file.t
+++ b/t/test_object-file.t
@@ -78,7 +78,7 @@ subtest 'Constructors' => sub {
         is( ref $obj, 'Object::Meta::File', "object 'Object::Meta::File': created correctly" );
 
         is( $obj->getName(),          'file2',       "Field 'name': set correctly" );
-        is( $obj->getDirectoryName(), 'directory2/', "Field 'name': set correctly" );
+        is( $obj->getDirectoryName(), 'directory2/', "Field 'directoryname': set correctly" );
         is( $obj->getIndexValue(),    $obj2hash,     "Field 'hash': has the index value" );
     };
 };
@@ -116,7 +116,7 @@ subtest 'Set Name' => sub {
         $obj->setDirectoryName('directory3');
 
         is( $obj->getName(),          'file3',       "Field 'name': set correctly" );
-        is( $obj->getDirectoryName(), 'directory3/', "Field 'name': set correctly" );
+        is( $obj->getDirectoryName(), 'directory3/', "Field 'directoryname': set correctly" );
         is( $obj->getIndexValue(),    $obj3hash,     "Field 'hash': has the index value" );
     };
 };

--- a/t/test_object-file.t
+++ b/t/test_object-file.t
@@ -1,0 +1,124 @@
+#!/usr/bin/perl
+
+# @author Bodo (Hugo) Barwich
+# @version 2026-01-29
+# @package Test for the Object::Meta::File Module
+# @subpackage t/test_object-file.t
+
+# This Module runs tests on the Object::Meta::File Module
+#
+#---------------------------------
+# Requirements:
+# - The Perl Module "Object::Meta::File" must be installed
+#
+
+use warnings;
+use strict;
+
+use Cwd         qw(abs_path);
+use Digest::MD5 qw(md5_hex);
+
+use Test::More;
+
+BEGIN {
+    use lib "lib";
+    use lib "../lib";
+}    #BEGIN
+
+require_ok('Object::Meta::File');
+
+use Object::Meta::File;
+
+my $smodule = "";
+my $spath   = abs_path($0);
+
+( $smodule = $spath ) =~ s/.*\/([^\/]+)$/$1/;
+$spath =~ s/^(.*\/)$smodule$/$1/;
+
+my $obj     = undef;
+my %objdata = ( 'name' => 'file1', 'directoryname' => 'directory1', 'field2' => 'value2', 'field3' => 'value3' );
+my $objhash = md5_hex('file1');
+
+subtest 'Constructors' => sub {
+
+    #------------------------
+    #Test: 'Constructors'
+
+    subtest 'empty object' => sub {
+        $obj = Object::Meta::File->new();
+
+        is( ref $obj, 'Object::Meta::File', "object 'Object::Meta::File': created correctly" );
+
+        is( $obj->getIndexField(),     'hash', "Field 'hash': is index field as expected" );
+        is( $obj->getName(),           '',     "Field 'name': is empty as expected" );
+        is( $obj->getDirectoryName(),  '',     "Field 'directoryname': is empty as expected" );
+        is( $obj->get( 'field2', '' ), '',     "Field 'field2': does not exist as expected" );
+    };
+    subtest 'object from data' => sub {
+        $obj = Object::Meta::File->new(%objdata);
+
+        is( ref $obj, 'Object::Meta::File', "object 'Object::Meta::File': created correctly" );
+
+        is( $obj->getIndexField(),    'hash',        "Field 'hash': is index field as expected" );
+        is( $obj->getName(),          'file1',       "Field 'name': set correctly" );
+        is( $obj->getDirectoryName(), 'directory1/', "Field 'directoryname': set correctly" );
+        is( $obj->getIndexValue(),    $objhash,      "Field 'hash': has the index value" );
+
+        foreach ( keys %objdata ) {
+            if ( $_ ne 'directoryname' ) {
+                is( $obj->get( $_, '' ), $objdata{$_}, "Field '$_': added correctly" );
+            }
+        }
+    };
+    subtest 'object from name' => sub {
+        my $obj2hash = md5_hex('file2');
+
+        $obj = Object::Meta::File->new( 'name' => 'file2', 'directoryname' => 'directory2' );
+
+        is( ref $obj, 'Object::Meta::File', "object 'Object::Meta::File': created correctly" );
+
+        is( $obj->getName(),          'file2',       "Field 'name': set correctly" );
+        is( $obj->getDirectoryName(), 'directory2/', "Field 'name': set correctly" );
+        is( $obj->getIndexValue(),    $obj2hash,     "Field 'hash': has the index value" );
+    };
+};
+
+subtest 'Set Name' => sub {
+
+    #------------------------
+    #Test: 'Set Name'
+
+    subtest 'object set data' => sub {
+        $obj = Object::Meta::File->new();
+
+        is( ref $obj, 'Object::Meta::File', "object 'Object::Meta::File': created correctly" );
+
+        $obj->set(%objdata);
+
+        is( $obj->getName(),          'file1',       "Field 'name': set correctly" );
+        is( $obj->getDirectoryName(), 'directory1/', "Field 'directoryname': set correctly" );
+        is( $obj->getIndexValue(),    $objhash,      "Field 'hash': has the index value" );
+
+        foreach ( keys %objdata ) {
+            if ( $_ ne 'directoryname' ) {
+                is( $obj->get( $_, '' ), $objdata{$_}, "Field '$_': added correctly" );
+            }
+        }
+    };
+    subtest 'object set name' => sub {
+        my $obj3hash = md5_hex('file3');
+
+        $obj = Object::Meta::File->new();
+
+        is( ref $obj, 'Object::Meta::File', "object 'Object::Meta::File': created correctly" );
+
+        $obj->setName('file3');
+        $obj->setDirectoryName('directory3');
+
+        is( $obj->getName(),          'file3',       "Field 'name': set correctly" );
+        is( $obj->getDirectoryName(), 'directory3/', "Field 'name': set correctly" );
+        is( $obj->getIndexValue(),    $obj3hash,     "Field 'hash': has the index value" );
+    };
+};
+
+done_testing();

--- a/t/test_pod-coverage.t
+++ b/t/test_pod-coverage.t
@@ -81,11 +81,21 @@ my %modules_expected = (
         file => 'lib/Object/Meta/Named.pm',
         expected_coverage => 1
     },
+    'Object::Meta::File' => {
+        package           => 'Object::Meta::File',
+        file              => 'lib/Object/Meta/File.pm',
+        expected_coverage => 1
+    },
     'Object::Meta::Named::List' => {
         package           => 'Object::Meta::Named::List',
         file => 'lib/Object/Meta/Named/List.pm',
         expected_coverage => 1
     },
+    'Object::Meta::File::List' => {
+        package           => 'Object::Meta::File::List',
+        file              => 'lib/Object/Meta/File/List.pm',
+        expected_coverage => 1
+    }
 );
 
 subtest 'Module POD Coverage' => sub {


### PR DESCRIPTION
Introducing the new `Object::Meta::File` which is designed to organise files in a list and add additional meta data to them and organise them by their meta data.

The documentation coverage is not impacted since those modules come with complete documentation.

Relates #1 